### PR TITLE
Fixing Nats URI validation issue

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/nats/util/NATSUtils.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/nats/util/NATSUtils.java
@@ -21,22 +21,30 @@ package org.wso2.extension.siddhi.io.nats.util;
 
 import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.Random;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Contains the utility functions required to the NATS extension.
  */
 public class NATSUtils {
     public static void validateNatsUrl(String natsServerUrl, String siddhiStreamName) {
-        String regex = "nats://(\\w*|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}):(\\d{1,5})";
-        Pattern p = Pattern.compile(regex);
-        Matcher matcher = p.matcher(natsServerUrl);
-        if (!matcher.find()) {
+        try {
+            URI uri = new URI(natsServerUrl);
+            String uriScheme = uri.getScheme();
+            if (!uri.getScheme().equals("nats")) {
+                throw new URISyntaxException(uri.toString(),
+                        "The provided URI scheme '" + uriScheme + "' is invalid; expected 'nats'");
+            }
+            if (uri.getHost() == null || uri.getPort() == -1) {
+                throw new URISyntaxException(uri.toString(),
+                        "URI must have host and port parts");
+            }
+        } catch (URISyntaxException e) {
             throw new SiddhiAppValidationException("Invalid NATS url: " + natsServerUrl + " received for stream: "
-                    + siddhiStreamName + ". Expected url format: nats://<host>:<port>");
+                    + siddhiStreamName + ". Expected url format: nats://<host>:<port>", e);
         }
     }
 


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the Nats URI validation issue. The existence regex validator does not allow to include '-' in the hostname, but the hostname labels may contain the ASCII letters 'a' through 'z' (in a case-insensitive manner), the digits '0' through '9', and the hyphen ('-'). 

## Goals
> Fix Nats URI validation logic to allow hyphen ('-') and other Internet standards characters.

## Approach
> Use URI to validate and extract scheme, hostname and port to further analyze results.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   >There are Docker tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A